### PR TITLE
AppCompat is only need it for testCompile scope

### DIFF
--- a/lynx/build.gradle
+++ b/lynx/build.gradle
@@ -36,9 +36,9 @@ apply plugin: 'android-unit-test'
 
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
-  compile 'com.android.support:appcompat-v7:21.0.3'
   compile 'com.github.pedrovgs:renderers:1.4'
   compile 'com.squareup:seismic:1.0.1'
+  testCompile 'com.android.support:appcompat-v7:21.0.3'
   testCompile 'org.robolectric:robolectric:2.3'
   testCompile 'junit:junit:4.10'
   testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
AppCompat is not need it for debug/release only for testing scope.
As a lib project it has to be mindful about the dependencies pulling down for developers. 
Not all developers want to have this extra dependencies that will increase their apk size and dalvik method cound.