### PR TITLE
Remove pending traces bug during restart Lynx process

### DIFF
--- a/lynx/src/main/java/com/github/pedrovgs/lynx/model/Lynx.java
+++ b/lynx/src/main/java/com/github/pedrovgs/lynx/model/Lynx.java
@@ -103,20 +103,21 @@ public class Lynx {
     logcat = (Logcat) logcat.clone();
     logcat.setListener(previousListener);
     lastNotificationTime = 0;
+    tracesToNotify.clear();
     logcat.start();
   }
 
   /**
    * Adds a Listener to the listeners collection to be notified with new Trace objects.
    */
-  public void registerListener(Listener lynxPresenter) {
+  public synchronized void registerListener(Listener lynxPresenter) {
     listeners.add(lynxPresenter);
   }
 
   /**
    * Removes a Listener to the listeners collection.
    */
-  public void unregisterListener(Listener lynxPresenter) {
+  public synchronized void unregisterListener(Listener lynxPresenter) {
     listeners.remove(lynxPresenter);
   }
 
@@ -164,15 +165,15 @@ public class Lynx {
     return timeFromLastNotification > lynxConfig.getSamplingRate() && hasTracesToNotify;
   }
 
-  private void notifyListeners(final List<Trace> traces) {
+  private synchronized void notifyListeners(final List<Trace> traces) {
     mainThread.post(new Runnable() {
       @Override public void run() {
         for (Listener listener : listeners) {
           listener.onNewTraces(traces);
         }
+        lastNotificationTime = timeProvider.getCurrentTimeMillis();
       }
     });
-    lastNotificationTime = timeProvider.getCurrentTimeMillis();
   }
 
   public interface Listener {

--- a/sample/src/instrumentTest/java/com/github/pedrovgs/sample/LynxActivityTest.java
+++ b/sample/src/instrumentTest/java/com/github/pedrovgs/sample/LynxActivityTest.java
@@ -224,8 +224,8 @@ public class LynxActivityTest extends ActivityInstrumentationTestCase2<MainActiv
   /**
    * Ugly sleep used for some of this tests. This method is needed because we can't provide Log
    * traces from the test application process and the default traces generation is implemented in
-   * MainActivity. onData method doesn't wait until our traces are displayed with the filter
-   * provided. That's why I need this Thread.Sleep. Please, don't do this at home.
+   * MainActivity. onData method doesn't wait until different log traces are displayed with the
+   * filter provided, that's why I need this Thread.Sleep. Please, don't do this at home.
    */
   private void waitForSomeTraces() {
     try {

--- a/sample/src/main/java/com/github/pedrovgs/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/pedrovgs/sample/MainActivity.java
@@ -25,7 +25,6 @@ import android.widget.Button;
 import com.github.pedrovgs.lynx.LynxActivity;
 import com.github.pedrovgs.lynx.LynxConfig;
 import com.github.pedrovgs.lynx.model.TraceLevel;
-import java.util.Random;
 
 /**
  * Activity created to show how to use Lynx.
@@ -84,17 +83,10 @@ public class MainActivity extends ActionBarActivity {
    * Random traces generator used just for this demo application.
    */
   private void generateFiveRandomTracesPerSecond() {
-    final Random random = new Random();
-    Log.d("Lynx", "Debug trace generated automatically");
-    Log.w("Lynx", "Warning trace generated automatically");
-    Log.e("Lynx", "Error trace generated automatically");
-    Log.wtf("Lynx", "WTF trace generated automatically");
-    Log.i("Lynx", "Info trace generated automatically");
-    Log.v("Lynx", "Verbose trace generated automatically");
     logGeneratorThread = new Thread(new Runnable() {
       @Override public void run() {
         while (continueReading) {
-          int traceLevel = random.nextInt(6);
+          int traceLevel = traceCounter % 6;
           switch (traceLevel) {
             case 0:
               Log.d("Lynx", traceCounter + " - Debug trace generated automatically");


### PR DESCRIPTION
I've found a bug related to the Lynx restart process. If you restart Lynx object and you have traces pending to be notified this traces will be shown when Lynx be restarted and your UI render the next list of traces.