### PR TITLE
Check that extras contain LYNX_CONFIG_EXTRA key

### DIFF
--- a/lynx/src/main/java/com/github/pedrovgs/lynx/LynxActivity.java
+++ b/lynx/src/main/java/com/github/pedrovgs/lynx/LynxActivity.java
@@ -69,7 +69,7 @@ public class LynxActivity extends Activity {
   private LynxConfig getLynxConfig() {
     Bundle extras = getIntent().getExtras();
     LynxConfig lynxConfig = new LynxConfig();
-    if (extras != null) {
+    if (extras != null && extras.containsKey(LYNX_CONFIG_EXTRA)) {
       lynxConfig = (LynxConfig) extras.getSerializable(LYNX_CONFIG_EXTRA);
     }
     return lynxConfig;


### PR DESCRIPTION
When LynxActivity is started from Launcher App the LinxView is initialize with a null LynxConfig because intentExtras is not null but hasn't LYNX_CONFIG_EXTRA