### PR TITLE
Add logic to prevent shake detection when on background.

### DIFF
--- a/lynx/src/main/java/com/github/pedrovgs/lynx/LynxShakeDetector.java
+++ b/lynx/src/main/java/com/github/pedrovgs/lynx/LynxShakeDetector.java
@@ -32,7 +32,11 @@ public class LynxShakeDetector {
   private final Context context;
 
   private static boolean isEnabled = true;
-  private static boolean keepAlwaysActive;
+  private static boolean keepAlwaysActive = false;
+
+  public LynxShakeDetector(Context context) {
+    this.context = context;
+  }
 
   public LynxShakeDetector(Context context, boolean keepAlwaysActive) {
     this.context = context;

--- a/lynx/src/main/java/com/github/pedrovgs/lynx/LynxShakeDetector.java
+++ b/lynx/src/main/java/com/github/pedrovgs/lynx/LynxShakeDetector.java
@@ -32,9 +32,11 @@ public class LynxShakeDetector {
   private final Context context;
 
   private static boolean isEnabled = true;
+  private static boolean keepAlwaysActive;
 
-  public LynxShakeDetector(Context context) {
+  public LynxShakeDetector(Context context, boolean keepAlwaysActive) {
     this.context = context;
+    this.keepAlwaysActive = keepAlwaysActive;
   }
 
   /**
@@ -46,6 +48,9 @@ public class LynxShakeDetector {
       @Override public void hearShake() {
         if (isEnabled) {
           openLynxActivity();
+          if (keepAlwaysActive) {
+            disable();
+          }
         }
       }
     });
@@ -56,15 +61,23 @@ public class LynxShakeDetector {
   /**
    * Enables shake detector to open LynxActivity on shake.
    */
-  static void enable() {
+  public static void enable() {
     isEnabled = true;
   }
 
   /**
    * Disables shake detector to open LynxActivity on shake.
    */
-  static void disable() {
+  public static void disable() {
     isEnabled = false;
+  }
+
+  /**
+   * Gets keep always active setting.
+   * @return true if shake detector should be always active, false otherwise.
+   */
+  public static boolean isKeepAlwaysActive() {
+    return keepAlwaysActive;
   }
 
   private void openLynxActivity() {

--- a/sample/src/main/java/com/github/pedrovgs/sample/LynxApplication.java
+++ b/sample/src/main/java/com/github/pedrovgs/sample/LynxApplication.java
@@ -29,7 +29,7 @@ public class LynxApplication extends Application {
 
   @Override public void onCreate() {
     super.onCreate();
-    LynxShakeDetector lynxShakeDetector = new LynxShakeDetector(this);
+    LynxShakeDetector lynxShakeDetector = new LynxShakeDetector(this, false);
     lynxShakeDetector.init();
   }
 }

--- a/sample/src/main/java/com/github/pedrovgs/sample/LynxApplication.java
+++ b/sample/src/main/java/com/github/pedrovgs/sample/LynxApplication.java
@@ -30,7 +30,7 @@ public class LynxApplication extends Application {
 
   @Override public void onCreate() {
     super.onCreate();
-    LynxShakeDetector lynxShakeDetector = new LynxShakeDetector(this, false);
+    LynxShakeDetector lynxShakeDetector = new LynxShakeDetector(this);
     LynxConfig lynxConfig = new LynxConfig();
     lynxConfig.setMaxNumberOfTracesToShow(4000).setFilter("LynxFilter");
     lynxShakeDetector.init(lynxConfig);

--- a/sample/src/main/java/com/github/pedrovgs/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/pedrovgs/sample/MainActivity.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.widget.Button;
 import com.github.pedrovgs.lynx.LynxActivity;
 import com.github.pedrovgs.lynx.LynxConfig;
+import com.github.pedrovgs.lynx.LynxShakeDetector;
 import com.github.pedrovgs.lynx.model.TraceLevel;
 
 /**
@@ -72,6 +73,20 @@ public class MainActivity extends ActionBarActivity {
 
     Intent lynxActivityIntent = LynxActivity.getIntent(this, lynxConfig);
     startActivity(lynxActivityIntent);
+  }
+
+  @Override protected void onPause() {
+    if (!LynxShakeDetector.isKeepAlwaysActive()) {
+      LynxShakeDetector.disable();
+    }
+    super.onPause();
+  }
+
+  @Override protected void onResume() {
+    super.onResume();
+    if (!LynxShakeDetector.isKeepAlwaysActive()) {
+      LynxShakeDetector.enable();
+    }
   }
 
   @Override protected void onDestroy() {


### PR DESCRIPTION
With these changes, shake detector can be still started from Application class, and disabled when going to background.

As required in the issue description (https://github.com/pedrovgs/Lynx/issues/14), this feature is configurable, and permanent shake can remain on place. In this case, to prevent launching more than one activity instance, shake detector will be disabled immediately after launching the first one.
