### PR TITLE
Toast rather than crash when sharing giant traces

### DIFF
--- a/lynx/src/main/java/com/github/pedrovgs/lynx/presenter/LynxPresenter.java
+++ b/lynx/src/main/java/com/github/pedrovgs/lynx/presenter/LynxPresenter.java
@@ -16,6 +16,8 @@
 
 package com.github.pedrovgs.lynx.presenter;
 
+import android.support.annotation.CheckResult;
+
 import com.github.pedrovgs.lynx.LynxConfig;
 import com.github.pedrovgs.lynx.model.Lynx;
 import com.github.pedrovgs.lynx.model.Trace;
@@ -121,7 +123,9 @@ public class LynxPresenter implements Lynx.Listener {
   public void onShareButtonClicked() {
     List<Trace> tracesToShare = new LinkedList<Trace>(traceBuffer.getTraces());
     String plainTraces = generatePlainTracesToShare(tracesToShare);
-    view.shareTraces(plainTraces);
+    if (!view.shareTraces(plainTraces)) {
+      view.notifyShareTracesFailed();
+    }
   }
 
   /**
@@ -212,7 +216,9 @@ public class LynxPresenter implements Lynx.Listener {
 
     void clear();
 
-    void shareTraces(String plainTraces);
+    @CheckResult boolean shareTraces(String plainTraces);
+
+    void notifyShareTracesFailed();
 
     void disableAutoScroll();
 


### PR DESCRIPTION
Fixes #25.

@pedrovgs unlike #30, there are several fairly different ways this issue could be addressed. I've included one in this PR, but am more than happy to discuss and make changes if you'd prefer a different solution. (For example, we could build an automatic retry with truncated traces into the `shareTraces` method.)